### PR TITLE
Fix regex pattern to make path field optional in packet parsing

### DIFF
--- a/aprspy/__init__.py
+++ b/aprspy/__init__.py
@@ -66,7 +66,7 @@ class APRS:
         try:
             # Parse out the source, destination, path and information fields
             (source, destination, path, data_type_id, info) = re.match(
-                r'([\w\d\-]+)>([\w\d\-]+),([\w\d\-\*\,]+):(.)(.*)',
+                r'([\w\d\-]+)>([\w\d\-]+)(?:,([\w\d\-\*\,]+))?:(.)(.*)',
                 packet
             ).groups()
         except AttributeError:


### PR DESCRIPTION
## Description:
This PR updates the regex pattern used in packet parsing to ensure that the `path` field is now optional. The change improves flexibility in handling packets with and without the `path` field while maintaining correct parsing behavior.

## Changes:
Modified regex pattern to properly handle cases where the `path` field is absent.

All tests have passed. Ready for review and merge.